### PR TITLE
Update dependencies due to elm 0.17 release

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.0",
+    "version": "2.0.0",
     "summary": "Decimal numbers for Elm",
     "repository": "https://github.com/javcasas/elm-decimal.git",
     "license": "BSD3",
@@ -10,8 +10,8 @@
         "Data.Decimal"
     ],
     "dependencies": {
-        "elm-lang/core": "3.0.0 <= v < 4.0.0",
-        "javcasas/elm-integer": "1.0.0 <= v < 2.0.0"
+        "elm-lang/core": "4.0.1 <= v < 5.0.0",
+        "javcasas/elm-integer": "2.0.0 <= v < 3.0.0"
     },
-    "elm-version": "0.16.0 <= v < 0.17.0"
+    "elm-version": "0.17.0 <= v < 0.18.0"
 }

--- a/src/Data/Decimal.elm
+++ b/src/Data/Decimal.elm
@@ -1,4 +1,4 @@
-module Data.Decimal
+module Data.Decimal exposing
     ( Decimal
     , fromInt
     , fromIntWithExponent
@@ -26,7 +26,7 @@ module Data.Decimal
     , truncate
     , round
     , getDigit
-    ) where
+    )
 
 
 {-|

--- a/src/Data/Decimal.elm
+++ b/src/Data/Decimal.elm
@@ -163,7 +163,7 @@ Converts a Decimal to a String
 -}
 toString : Decimal -> String
 toString (Decimal m e) =
-    let abs_m = if m `Data.Integer.gte` (Data.Integer.fromInt 0) then m else Data.Integer.opposite m
+    let abs_m = if m `Data.Integer.gte` (Data.Integer.fromInt 0) then m else Data.Integer.negate m
         s = Data.Integer.toString abs_m
         sign = if m `Data.Integer.gte` (Data.Integer.fromInt 0) then "" else "-"
         add_zeros n = String.repeat n "0"
@@ -233,7 +233,7 @@ add a b =
 Changes the sign of a Decimal
 -}
 negate : Decimal -> Decimal
-negate (Decimal m e) = Decimal (Data.Integer.opposite m) e
+negate (Decimal m e) = Decimal (Data.Integer.negate m) e
 
 {-|
 Substraction
@@ -254,7 +254,7 @@ Absolute value (sets the sign as positive)
 abs : Decimal -> Decimal
 abs (Decimal m e) =
     case Data.Integer.compare m (Data.Integer.fromInt 0) of
-        LT -> Decimal (Data.Integer.opposite m) e
+        LT -> Decimal (Data.Integer.negate m) e
         _ -> Decimal m e
 
 {-|

--- a/test/Test.elm
+++ b/test/Test.elm
@@ -1,3 +1,5 @@
+module Main exposing (..)
+
 import Data.Decimal exposing (..)
 import Maybe exposing (Maybe, andThen)
 import ElmTest exposing (..)
@@ -209,6 +211,6 @@ allTests =
         , (Check.Test.evidenceToTest (quickCheck qcCompare))
         ]
 
-main : Element
+
 main = 
-    elementRunner allTests
+    runSuiteHtml allTests

--- a/test/elm-package.json
+++ b/test/elm-package.json
@@ -11,10 +11,10 @@
         ""
     ],
     "dependencies": {
-        "NoRedInk/elm-check": "3.0.0 <= v < 4.0.0",
-        "deadfoxygrandpa/elm-test": "3.1.1 <= v < 4.0.0",
-        "elm-lang/core": "3.0.0 <= v < 4.0.0",
-        "javcasas/elm-integer": "1.0.0 <= v < 2.0.0"
+        "elm-community/elm-check": "1.0.2 <= v < 2.0.0",
+        "elm-community/elm-test": "1.1.0 <= v < 2.0.0",
+        "elm-lang/core": "4.0.1 <= v < 5.0.0",
+        "javcasas/elm-integer": "2.0.0 <= v < 3.0.0"
     },
-    "elm-version": "0.16.0 <= v < 0.17.0"
+    "elm-version": "0.17.0 <= v < 0.18.0"
 }


### PR DESCRIPTION
Hi,

Same changes as for `elm-integer`. I've already updated `elm-integer` dependency version for this package to `2.0.0`. 
